### PR TITLE
Fix Dockerfile syntax change from previous Pr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ruby iFROM ruby:2.7.4
+FROM ruby:2.7.4
 
 RUN apt-get update && \
   apt-get install -y \


### PR DESCRIPTION
When I went to build a new Docker image on my main it did not like how the dockerfile was converted on the previous PR. I changed it back

# Type of Change

  [] New Feature
  
  [x] Bug Fix
  
  [] Refactor
  
  [] Other (Please Describe)

  Description:  When I went to build a new docker image, it did not like the previous syntax. It appeared to be changed on the previous PR but I think it was done by an extension on Alex's computer. 

## Neccesary checkmarks:

   [x] All Tests are Passing

   [x] The code will run locally

## Testing Changes

### Description of Test changes:



## Checklists 

[x] I have reviewed my code

[x] I have fully tested my code
